### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.3.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.2.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ See below for how to generate the SmartThings api_endpoint and api_key
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Actions
 
 * `disengage_lock`  - Disengage (lock) a device that can be locked

--- a/actions/set_mode.yaml
+++ b/actions/set_mode.yaml
@@ -1,6 +1,6 @@
 ---
 name: "set_mode"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Set current temperature."
 enabled: true
 entry_point: "command.py"

--- a/actions/set_temperature.yaml
+++ b/actions/set_temperature.yaml
@@ -1,6 +1,6 @@
 ---
 name: "set_temperature"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Set current temperature."
 enabled: true
 entry_point: "command.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords:
   - iot
   - smart home
   - home automation
-version: 0.2.0
+version: 0.3.0
 author: James Fryman
 email: james@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.